### PR TITLE
Increase audio button touch target

### DIFF
--- a/deck-source/templates/eggrolls-FREQ60K-MWLD-v1-styles.css
+++ b/deck-source/templates/eggrolls-FREQ60K-MWLD-v1-styles.css
@@ -536,8 +536,8 @@ ul, ol {
     padding: 0;
     margin: 0;
     margin-left: var(--spacing-xs);
-    width: var(--audio-button-size);
-    height: var(--audio-button-size);
+    width: 48px;
+    height: 48px;
     background: none !important;
     border: none !important;
     border-radius: 0;


### PR DESCRIPTION
Set the pronunciation row audio-button size variable to 48px on narrow screens and coarse-pointer devices, covering phone portrait and landscape for both audio and translate controls.