### PR TITLE
Increase mobile audio button touch targets

### DIFF
--- a/deck-source/templates/eggrolls-FREQ60K-MWLD-v1-styles.css
+++ b/deck-source/templates/eggrolls-FREQ60K-MWLD-v1-styles.css
@@ -510,6 +510,12 @@ ul, ol {
   transform: none;
 }
 
+@media (pointer: coarse) {
+  .pronunciation-audio {
+    --audio-button-size: 48px;
+  }
+}
+
 @media (max-width: 520px) {
   :root {
     --card-padding-inline: calc(var(--spacing-base) - var(--spacing-xs));


### PR DESCRIPTION
Increase the pronunciation-row controls to a 48px touch target on coarse-pointer devices.

This applies to the front/back audio buttons as well as the back translate button through the existing `--audio-button-size` variable, without changing desktop mouse layouts just because the window is narrow.

Why: mobile design guidelines commonly use 44-48px as the minimum practical touch target size. Apple recommends at least 44x44 pt for button hit regions, and Material Design recommends at least 48x48 dp touch targets.

References:
- Apple HIG Buttons: https://developer.apple.com/design/human-interface-guidelines/buttons
- Material Design touch targets: https://m3.material.io/foundations/designing/structure